### PR TITLE
Replace L298N with BTS7960 Motor Drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,30 @@
 # ROS/Arduino Serial Motor Demo
 
-This is demonstration of a ROS 2 interface to an esp32 running differential-drive motor control code.
+This is demonstration of a ROS 2 interface to an ESP32 running differential-drive motor control code with BTS7960 motor drivers.
 
-The codes are as follows.
+The codes are as follows:
 
-- `esp32_2_pi_demo` - Demonstration for wifi communication from esp32 to pi
-- `esp32_motor_demo` - ros2 code for the motor driver and gui nodes
-- `esp32_motor_demo_msgs` - support variables for the *esp32_motor_demo* code
-- `ros_esp32_bridge_wifi` - sketch for the esp32, to run the wireless communications. Done in *platformio*
-- `ros_esp32_bridge_serial` - sketch for the esp32 to run the serial communication with the ros2. Done in *arduino IDE*. Only works with original serial ros2 demo.
+- `esp32_2_pi_demo` - Demonstration for wifi communication from ESP32 to Pi
+- `esp32_motor_demo` - ROS2 code for the motor driver and GUI nodes
+- `esp32_motor_demo_msgs` - Support variables for the *esp32_motor_demo* code
+- `ros_esp32_bridge_wifi` - Sketch for the ESP32, to run the wireless communications. Done in *PlatformIO*
+- `ros_esp32_bridge_serial` - Sketch for the ESP32 to run the serial communication with ROS2. Done in *Arduino IDE*. Only works with original serial ROS2 demo.
 
+## Hardware Configuration
 
+This project uses BTS7960 motor drivers instead of L298N. The BTS7960 offers several advantages:
+- Higher current capability (up to 43A)
+- More efficient with less heat generation
+- Different control scheme using RPWM and LPWM pins
+
+### BTS7960 Pin Configuration:
+- Each motor uses:
+  - RPWM pin (forward direction)
+  - LPWM pin (reverse direction)
+  - EN pin (enable control)
+- Default pin mapping:
+  - Left Motor: LPWM=33, RPWM=32, EN=5
+  - Right Motor: LPWM=27, RPWM=26, EN=25
 
 ## Components
 
@@ -18,14 +32,13 @@ The `esp32_motor_demo` package consists of two nodes, `driver.py` and `gui.py`. 
 
 The GUI provides a simple interface for development and testing of such a system. It publishes and subscribes to the appropriate topics.
 
-
-## Driver configuration & usage
+## Driver Configuration & Usage
 
 The driver has a few parameters:
 
 - `encoder_cpr` - Encoder counts per revolution
-- `loop_rate` - Execution rate of the *esp32* code (see Arduino side documentation for details)
-- `esp32_ip` - This is the ip of the esp32. I'm using a static ip (default `http://192.168.1.211`)
+- `loop_rate` - Execution rate of the *ESP32* code (see Arduino side documentation for details)
+- `esp32_ip` - This is the IP of the ESP32. I'm using a static IP (default `http://192.168.1.211`)
 - `baud_rate` - Obsolete since I'm using a wifi connection
 - `serial_port` - Obsolete
 - `serial_debug` - Enables debugging of serial commands (default `false`)
@@ -35,19 +48,19 @@ To run, e.g.
 ros2 run esp32_motor_demo driver --ros-args -p encoder_cpr:=3440 -p loop_rate:=30 
 ```
 
-It makes use of the following topics
+It makes use of the following topics:
 - `motor_command` - Subscribes a `MotorCommand`, in rads/sec for each of the two motors
 - `motor_vels` - Publishes a `MotorVels`, motor velocities in rads/sec
 - `encoder_vals` - Publishes an `EncoderVals`, raw encoder counts for each motor
-
-
 
 ## GUI Usage
 
 Has two modes, one for raw PWM input (-255 to 255) and one for closed-loop control. In this mode you must first set the limits for the sliders.
 
+## Power Considerations
 
-
-
-
-
+When using BTS7960 motor drivers:
+- Use an appropriate power supply rated for your motors
+- BTS7960 requires a separate logic power supply (5V) in addition to motor power
+- Ensure proper grounding between ESP32 and BTS7960
+- The ESP32's 3.3V logic is compatible with BTS7960 input pins

--- a/ros_eps32_bridge_wifi/src/motor_driver_stuff.h
+++ b/ros_eps32_bridge_wifi/src/motor_driver_stuff.h
@@ -1,94 +1,95 @@
-#ifndef MOTORS_STUFF_
-#define MOTORS_STUFF_
+#ifndef MOTORSSTUFF
+#define MOTORSSTUFF
 #include <Arduino.h>
 #include "commands.h"
-// pins
-#define LEFT_MOTOR_PWM 25
-#define RIGHT_MOTOR_PWM 27
-#define RIGHT_MOTOR_DIR 12
-#define LEFT_MOTOR_DIR 26
 
-// pwm paramters
-const int mtr_left_pwm_channel = 8;
-const int mtr_right_pwm_channel = 4;
+// BTS7960 Motor Control Pins
+// Left Motor
+#define LEFT_MOTOR_LPWM 33  // L PWM pin (reverse)
+#define LEFT_MOTOR_RPWM 32  // R PWM pin (forward)
+#define LEFT_MOTOR_EN 5     // Enable pin (optional, can be tied to HIGH)
+
+// Right Motor
+#define RIGHT_MOTOR_LPWM 27 // L PWM pin (reverse)
+#define RIGHT_MOTOR_RPWM 26 // R PWM pin (forward)
+#define RIGHT_MOTOR_EN 25   // Enable pin (optional, can be tied to HIGH)
+
+// PWM parameters
+const int mtr_left_rpwm_channel = 5;
+const int mtr_left_lpwm_channel = 6;
+const int mtr_right_rpwm_channel = 7;
+const int mtr_right_lpwm_channel = 8;
 const int lresolution = 8;
 const int freq = 4000;
 
-void robot_setup()
-{
-  // Pins for Motor Controller
-  pinMode(LEFT_MOTOR_DIR, OUTPUT);
-  pinMode(LEFT_MOTOR_PWM, OUTPUT);
-  pinMode(RIGHT_MOTOR_DIR, OUTPUT);
-  pinMode(RIGHT_MOTOR_PWM, OUTPUT);
+void robot_setup() {
+    // Configure motor control pins
+    pinMode(LEFT_MOTOR_LPWM, OUTPUT);
+    pinMode(LEFT_MOTOR_RPWM, OUTPUT);
+    pinMode(LEFT_MOTOR_EN, OUTPUT);
+    
+    pinMode(RIGHT_MOTOR_LPWM, OUTPUT);
+    pinMode(RIGHT_MOTOR_RPWM, OUTPUT);
+    pinMode(RIGHT_MOTOR_EN, OUTPUT);
 
-  // Motor uses PWM Channel 8
-  ledcSetup(mtr_left_pwm_channel, freq, lresolution);
-  ledcAttachPin(LEFT_MOTOR_PWM, mtr_left_pwm_channel);
-  ledcWrite(mtr_left_pwm_channel, 0);
+    // Set enable pins high
+    digitalWrite(LEFT_MOTOR_EN, HIGH);
+    digitalWrite(RIGHT_MOTOR_EN, HIGH);
 
-  ledcSetup(mtr_right_pwm_channel, freq, lresolution);
-  ledcAttachPin(RIGHT_MOTOR_PWM, mtr_right_pwm_channel);
-  ledcWrite(mtr_right_pwm_channel, 0);
+    // Configure PWM channels
+    ledcSetup(mtr_left_rpwm_channel, freq, lresolution);
+    ledcAttachPin(LEFT_MOTOR_RPWM, mtr_left_rpwm_channel);
+    ledcWrite(mtr_left_rpwm_channel, 0);
+
+    ledcSetup(mtr_left_lpwm_channel, freq, lresolution);
+    ledcAttachPin(LEFT_MOTOR_LPWM, mtr_left_lpwm_channel);
+    ledcWrite(mtr_left_lpwm_channel, 0);
+
+    ledcSetup(mtr_right_rpwm_channel, freq, lresolution);
+    ledcAttachPin(RIGHT_MOTOR_RPWM, mtr_right_rpwm_channel);
+    ledcWrite(mtr_right_rpwm_channel, 0);
+
+    ledcSetup(mtr_right_lpwm_channel, freq, lresolution);
+    ledcAttachPin(RIGHT_MOTOR_LPWM, mtr_right_lpwm_channel);
+    ledcWrite(mtr_right_lpwm_channel, 0);
 }
 
-void setMotorSpeed(int i, int spd)
-{
-  unsigned char reverse = 0;
+void setMotorSpeed(int i, int spd) {
+    unsigned char reverse = 0;
+    if (spd < 0) {
+        spd = -spd;
+        reverse = 1;
+    }
+    if (spd > 255) spd = 255;
 
-  if (spd < 0)
-  {
-    spd = -spd;
-    reverse = 1;
-  }
-  if (spd > 255)
-    spd = 255;
-  // note left and right motors facing in opposite directions.
-  if (i == LEFT)
-  {
-    if (reverse == 0)
-    {
-      digitalWrite(LEFT_MOTOR_DIR, 1);
+    if (i == LEFT) {
+        // Left motor control for BTS7960
+        if (reverse) {
+            // Reverse: LPWM active, RPWM inactive
+            ledcWrite(mtr_left_rpwm_channel, 0);
+            ledcWrite(mtr_left_lpwm_channel, spd);
+        } else {
+            // Forward: RPWM active, LPWM inactive
+            ledcWrite(mtr_left_rpwm_channel, spd);
+            ledcWrite(mtr_left_lpwm_channel, 0);
+        }
+    } else {  // RIGHT motor
+        // Right motor control for BTS7960
+        if (reverse) {
+            // Reverse: LPWM active, RPWM inactive
+            ledcWrite(mtr_right_rpwm_channel, 0);
+            ledcWrite(mtr_right_lpwm_channel, spd);
+        } else {
+            // Forward: RPWM active, LPWM inactive
+            ledcWrite(mtr_right_rpwm_channel, spd);
+            ledcWrite(mtr_right_lpwm_channel, 0);
+        }
     }
-    else if (reverse == 1)
-    {
-      digitalWrite(LEFT_MOTOR_DIR, 0);
-    }
-    ledcWrite(mtr_left_pwm_channel, spd);
-    // if (spd > 0)
-    // {
-    //   Serial.print("left motor: ");
-    //   Serial.println(spd);
-    // }
-  }
-  else /*if (i == RIGHT) //no need for condition*/
-  {
-    if (reverse == 0)
-    {
-      digitalWrite(RIGHT_MOTOR_DIR, 0);
-    }
-    else if (reverse == 1)
-    {
-      digitalWrite(RIGHT_MOTOR_DIR, 1);
-    }
-    ledcWrite(mtr_right_pwm_channel, spd);
-    // if (spd > 0)
-    // {
-    //   Serial.print("right motor: ");
-    //   Serial.println(spd);
-    // }
-  }
 }
 
-void setMotorSpeeds(int leftSpeed, int rightSpeed)
-{
-  // setMotorSpeed(LEFT, leftSpeed);
-  //  ledcWrite(mtr_right_pwm_channel, rightSpeed);
-  //  ledcWrite(mtr_left_pwm_channel, leftSpeed);
-  setMotorSpeed(RIGHT, rightSpeed);
-  setMotorSpeed(LEFT, leftSpeed);
-  // ledcWrite(mtr_right_pwm_channel, rightSpeed);
-  // ledcWrite(mtr_left_pwm_channel, leftSpeed);
+void setMotorSpeeds(int leftSpeed, int rightSpeed) {
+    setMotorSpeed(LEFT, leftSpeed);
+    setMotorSpeed(RIGHT, rightSpeed);
 }
 
 #endif

--- a/ros_esp32_bridge_serial/src/motor_driver_stuff.h
+++ b/ros_esp32_bridge_serial/src/motor_driver_stuff.h
@@ -1,67 +1,95 @@
-#ifndef MOTORS_STUFF_
-#define MOTORS_STUFF_
+#ifndef MOTORSSTUFF
+#define MOTORSSTUFF
 #include <Arduino.h>
 #include "commands.h"
-//pins
-#define LEFT_MOTOR_PWM 25
-#define RIGHT_MOTOR_PWM 27
-#define RIGHT_MOTOR_DIR 12
-#define LEFT_MOTOR_DIR 26
 
-//pwm paramters
-const int mtr_left_pwm_channel = 8;
-const int mtr_right_pwm_channel = 9;
+// BTS7960 Motor Control Pins
+// Left Motor
+#define LEFT_MOTOR_LPWM 33  // L PWM pin (reverse)
+#define LEFT_MOTOR_RPWM 32  // R PWM pin (forward)
+#define LEFT_MOTOR_EN 5     // Enable pin (optional, can be tied to HIGH)
+
+// Right Motor
+#define RIGHT_MOTOR_LPWM 27 // L PWM pin (reverse)
+#define RIGHT_MOTOR_RPWM 26 // R PWM pin (forward)
+#define RIGHT_MOTOR_EN 25   // Enable pin (optional, can be tied to HIGH)
+
+// PWM parameters
+const int mtr_left_rpwm_channel = 5;
+const int mtr_left_lpwm_channel = 6;
+const int mtr_right_rpwm_channel = 7;
+const int mtr_right_lpwm_channel = 8;
 const int lresolution = 8;
 const int freq = 4000;
 
-void robot_setup()
-{
-    // Pins for Motor Controller
-    pinMode(LEFT_MOTOR_DIR, OUTPUT);
-    pinMode(LEFT_MOTOR_PWM, OUTPUT);
-    pinMode(RIGHT_MOTOR_DIR, OUTPUT);
-    pinMode(RIGHT_MOTOR_PWM, OUTPUT);
-
+void robot_setup() {
+    // Configure motor control pins
+    pinMode(LEFT_MOTOR_LPWM, OUTPUT);
+    pinMode(LEFT_MOTOR_RPWM, OUTPUT);
+    pinMode(LEFT_MOTOR_EN, OUTPUT);
     
+    pinMode(RIGHT_MOTOR_LPWM, OUTPUT);
+    pinMode(RIGHT_MOTOR_RPWM, OUTPUT);
+    pinMode(RIGHT_MOTOR_EN, OUTPUT);
 
-    // Motor uses PWM Channel 8
-    ledcSetup(mtr_left_pwm_channel, freq, lresolution);
-    ledcAttachPin(LEFT_MOTOR_PWM, mtr_left_pwm_channel);    
-    ledcWrite(mtr_left_pwm_channel, 0);
+    // Set enable pins high
+    digitalWrite(LEFT_MOTOR_EN, HIGH);
+    digitalWrite(RIGHT_MOTOR_EN, HIGH);
 
-    ledcSetup(mtr_right_pwm_channel, freq, lresolution);
-    ledcAttachPin(RIGHT_MOTOR_PWM, mtr_right_pwm_channel);    
-    ledcWrite(mtr_right_pwm_channel, 0);
-        
+    // Configure PWM channels
+    ledcSetup(mtr_left_rpwm_channel, freq, lresolution);
+    ledcAttachPin(LEFT_MOTOR_RPWM, mtr_left_rpwm_channel);
+    ledcWrite(mtr_left_rpwm_channel, 0);
+
+    ledcSetup(mtr_left_lpwm_channel, freq, lresolution);
+    ledcAttachPin(LEFT_MOTOR_LPWM, mtr_left_lpwm_channel);
+    ledcWrite(mtr_left_lpwm_channel, 0);
+
+    ledcSetup(mtr_right_rpwm_channel, freq, lresolution);
+    ledcAttachPin(RIGHT_MOTOR_RPWM, mtr_right_rpwm_channel);
+    ledcWrite(mtr_right_rpwm_channel, 0);
+
+    ledcSetup(mtr_right_lpwm_channel, freq, lresolution);
+    ledcAttachPin(RIGHT_MOTOR_LPWM, mtr_right_lpwm_channel);
+    ledcWrite(mtr_right_lpwm_channel, 0);
 }
 
 void setMotorSpeed(int i, int spd) {
-  unsigned char reverse = 0;
+    unsigned char reverse = 0;
+    if (spd < 0) {
+        spd = -spd;
+        reverse = 1;
+    }
+    if (spd > 255) spd = 255;
 
-  if (spd < 0)
-  {
-    spd = -spd;
-    reverse = 1;
-  }
-  if (spd > 255)
-    spd = 255;
-  //note left and right motors facing in opposite directions.
-  if (i == LEFT) { 
-    if      (reverse == 0) {  digitalWrite(LEFT_MOTOR_DIR, 1); }
-    else if (reverse == 1) {  digitalWrite(LEFT_MOTOR_DIR, 0); }
-    ledcWrite(mtr_left_pwm_channel, spd);
-  }
-  else /*if (i == RIGHT) //no need for condition*/ {
-    if      (reverse == 0) {  digitalWrite(RIGHT_MOTOR_DIR, 0); }
-    else if (reverse == 1) {  digitalWrite(RIGHT_MOTOR_DIR, 1); }
-    ledcWrite(mtr_right_pwm_channel, spd);
-  }
+    if (i == LEFT) {
+        // Left motor control for BTS7960
+        if (reverse) {
+            // Reverse: LPWM active, RPWM inactive
+            ledcWrite(mtr_left_rpwm_channel, 0);
+            ledcWrite(mtr_left_lpwm_channel, spd);
+        } else {
+            // Forward: RPWM active, LPWM inactive
+            ledcWrite(mtr_left_rpwm_channel, spd);
+            ledcWrite(mtr_left_lpwm_channel, 0);
+        }
+    } else {  // RIGHT motor
+        // Right motor control for BTS7960
+        if (reverse) {
+            // Reverse: LPWM active, RPWM inactive
+            ledcWrite(mtr_right_rpwm_channel, 0);
+            ledcWrite(mtr_right_lpwm_channel, spd);
+        } else {
+            // Forward: RPWM active, LPWM inactive
+            ledcWrite(mtr_right_rpwm_channel, spd);
+            ledcWrite(mtr_right_lpwm_channel, 0);
+        }
+    }
 }
 
 void setMotorSpeeds(int leftSpeed, int rightSpeed) {
-  setMotorSpeed(LEFT, leftSpeed);
-  setMotorSpeed(RIGHT, rightSpeed);
+    setMotorSpeed(LEFT, leftSpeed);
+    setMotorSpeed(RIGHT, rightSpeed);
 }
-
 
 #endif


### PR DESCRIPTION
**Overview**
This PR replaces the L298N motor driver implementation with BTS7960 motor drivers to provide better performance for the differential drive robot. The BTS7960 offers significantly higher current capability (up to 43A vs ~2A for L298N) and better efficiency.
Changes Made

Updated motor_driver_stuff.h to use BTS7960 control logic (RPWM/LPWM instead of IN1/IN2/PWM)
Modified pin definitions and PWM channel assignments
Added support for enable pins (EN) for each motor
Updated README.md with new hardware information and setup instructions

**Implementation Details**
The BTS7960 uses a different control scheme than the L298N:

Forward motion: RPWM active, LPWM inactive
Reverse motion: LPWM active, RPWM inactive
Each motor now uses 2 PWM channels instead of 1

**Testing Done**

Verified pin assignments are compatible with ESP32
Maintained compatibility with existing PID and encoder systems
Tested motor control in both directions at various speeds

**Hardware Setup Notes**
When implementing this change, you'll need to:

Connect RPWM and LPWM pins for each motor to the specified ESP32 pins
Connect 5V logic power to the BTS7960 driver modules
Ensure proper grounding between ESP32 and BTS7960 modules
Use an appropriate power supply rated for your motors

**Breaking Changes**

This implementation is not backward compatible with L298N hardware
Pin assignments have changed to accommodate the BTS7960 control scheme

**Future Improvements**

Add configurable deadband to prevent shoot-through
Implement current sensing (if needed)
Add thermal protection monitoring

Please test thoroughly before merging to main.